### PR TITLE
Change I2C speed to 400KHz

### DIFF
--- a/src/AnalogExpansion.cpp
+++ b/src/AnalogExpansion.cpp
@@ -694,7 +694,9 @@ void AnalogExpansion::setDac(uint8_t ch, uint16_t value,
     uint8_t t = 0;
     do {
       err = execute(SET_SINGLE_ANALOG_OUTPUT);
-      delay(5);
+      if(err) {
+        delay(5);
+      }
       t++;
     } while(err != EXECUTE_OK && t < 3);
 

--- a/src/DigitalExpansion.h
+++ b/src/DigitalExpansion.h
@@ -73,7 +73,7 @@ public:
    * transaction */
   void digitalWrite(int pin, PinStatus st, bool update = false);
 
-  /* get the status ha digital output has been set */
+  /* get the status digital output has been set */
   PinStatus digitalOutRead(int pin);
 
   /* get the status of a digital input

--- a/src/OptaController.cpp
+++ b/src/OptaController.cpp
@@ -302,6 +302,7 @@ void Controller::begin() {
   pinMode(OPTA_CONTROLLER_DETECT_PIN, INPUT_PULLUP);
   /* initialize the controller as I2C MASTER */
   Wire.begin();
+  Wire.setClock(400000);
 
   _send(OPTA_CONTROLLER_FIRST_AVAILABLE_ADDRESS, msg_opta_reset(), 0);
   delay(OPTA_CONTROLLER_SETUP_INIT_DELAY);

--- a/tests/measureI2CtransactionAnalog/measureI2CtransactionAnalog.ino
+++ b/tests/measureI2CtransactionAnalog/measureI2CtransactionAnalog.ino
@@ -1,0 +1,176 @@
+#include "OptaBlue.h"
+
+#define OPTA_CONTROLLER_DETECT_PIN PG_8
+
+#define EXPANSION_INDEX 0
+
+//#define MEASURE_RTD
+//#define MEASURE_ADC_SINGLE
+//#define MEASURE_ADC_SINGLE_WITH_CONVERSION
+//#define MEASURE_ADC_ALL_AT_ONCE
+//#define MEASURE_ALL_DIGITAL_INPUT
+//#define MEASURE_ALL_DIGITAL_INPUT_AT_ONCE
+//#define MEASURE_WRITE_SINGLE_DAC_CHANNEL
+//#define MEASURE_WRITE_ALL_DAC
+#define MEASURE_WRITE_PWM 
+
+AnalogExpansion aexp;
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial) {
+    
+  }
+  Serial.println("TEST SETUP for measuring I2C timing");
+  OptaController.begin();
+  
+  pinMode(OPTA_CONTROLLER_DETECT_PIN, INPUT_PULLUP);
+  pinMode(LED_USER, OUTPUT);
+  pinMode(BTN_USER, INPUT);
+
+  aexp = OptaController.getExpansion(EXPANSION_INDEX);
+  if(aexp) {
+     #ifdef MEASURE_RTD
+     aexp.beginChannelAsRtd(0, false, 1.2);
+     #endif
+
+     #ifdef MEASURE_ADC_SINGLE
+     aexp.beginChannelAsVoltageAdc(0);
+     #endif
+
+     #ifdef MEASURE_ADC_SINGLE_WITH_CONVERSION
+     aexp.beginChannelAsVoltageAdc(0);
+     #endif
+
+     #ifdef MEASURE_ADC_ALL_AT_ONCE
+     aexp.beginChannelAsVoltageAdc(0);
+     aexp.beginChannelAsVoltageAdc(1);
+     aexp.beginChannelAsVoltageAdc(2);
+     aexp.beginChannelAsVoltageAdc(3);
+     aexp.beginChannelAsVoltageAdc(4);
+     aexp.beginChannelAsVoltageAdc(5);
+     aexp.beginChannelAsVoltageAdc(6);
+     aexp.beginChannelAsVoltageAdc(7);
+     #endif
+
+     #ifdef MEASURE_ALL_DIGITAL_INPUT
+     aexp.beginChannelAsDigitalInput(0);
+     aexp.beginChannelAsDigitalInput(1);
+     aexp.beginChannelAsDigitalInput(2);
+     aexp.beginChannelAsDigitalInput(3);
+     aexp.beginChannelAsDigitalInput(4);
+     aexp.beginChannelAsDigitalInput(5);
+     aexp.beginChannelAsDigitalInput(6);
+     aexp.beginChannelAsDigitalInput(7);
+     #endif
+
+     #ifdef MEASURE_ALL_DIGITAL_INPUT_AT_ONCE
+     aexp.beginChannelAsDigitalInput(0);
+     aexp.beginChannelAsDigitalInput(1);
+     aexp.beginChannelAsDigitalInput(2);
+     aexp.beginChannelAsDigitalInput(3);
+     aexp.beginChannelAsDigitalInput(4);
+     aexp.beginChannelAsDigitalInput(5);
+     aexp.beginChannelAsDigitalInput(6);
+     aexp.beginChannelAsDigitalInput(7);
+     #endif
+
+     #ifdef MEASURE_WRITE_SINGLE_DAC_CHANNEL
+     aexp.beginChannelAsVoltageDac(0);
+     #endif
+
+     #ifdef MEASURE_WRITE_ALL_DAC
+     aexp.beginChannelAsVoltageDac(0);
+     aexp.beginChannelAsVoltageDac(1);
+     aexp.beginChannelAsVoltageDac(2);
+     aexp.beginChannelAsVoltageDac(3);
+     aexp.beginChannelAsVoltageDac(4);
+     aexp.beginChannelAsVoltageDac(5);
+     aexp.beginChannelAsVoltageDac(6);
+     aexp.beginChannelAsVoltageDac(7);
+     #endif
+
+     
+  }
+  else {
+    while(1) {
+      Serial.println("Analog expansion not found");
+      delay(1000);
+    }
+  }
+
+}
+
+void loop() {
+  OptaController.update();
+  static int counter = 0;
+  static int measure = 0;
+  digitalWrite(LED_USER,LOW);
+  if(digitalRead(BTN_USER) == LOW) {
+    counter++;
+    if(counter > 10000) {
+      measure++;
+    }
+  }
+  else {
+    counter=0;
+    measure = 0;
+  }
+  if(measure == 1) {
+    digitalWrite(LED_USER,HIGH);
+    float v = 0;
+    #ifdef MEASURE_RTD
+    Serial.println("executing aexp.getRtd(0);");
+    v = aexp.getRtd(0);
+    #endif
+    #ifdef MEASURE_ADC_SINGLE
+    Serial.println("executing aexp.getAdc(0, true);");
+    v = aexp.getAdc(0, true);
+    #endif
+
+    #ifdef MEASURE_ADC_SINGLE_WITH_CONVERSION
+    Serial.println("executing aexp.pinVoltage(0, true);");
+    v = aexp.pinVoltage(0, true);
+    #endif
+
+    #ifdef MEASURE_ADC_ALL_AT_ONCE
+    Serial.println("executing aexp.updateAnalogInputs();");
+    aexp.updateAnalogInputs();
+    v = aexp.getAdc(0, false);
+    #endif
+
+    #ifdef MEASURE_ALL_DIGITAL_INPUT
+    Serial.println("executing aexp.digitalRead(0, true);");
+    v = aexp.digitalRead(0, true);
+    #endif
+
+    #ifdef MEASURE_ALL_DIGITAL_INPUT_AT_ONCE
+    Serial.println("executing aexp.updateDigitalInputs();");
+    aexp.updateDigitalInputs();
+    v = aexp.digitalRead(0, false);
+    #endif
+
+    #ifdef MEASURE_WRITE_SINGLE_DAC_CHANNEL
+    Serial.println("executing aexp.setDac(0, 5050, true);");
+    aexp.setDac(0, 5050, true);
+    #endif
+
+    #ifdef MEASURE_WRITE_ALL_DAC
+    Serial.println("executing aexp.updateAnalogOutputs();");
+    aexp.setDac(0, 5050, false);
+    aexp.updateAnalogOutputs();
+    #endif
+
+    #ifdef MEASURE_WRITE_PWM
+    Serial.println("executing aexp.etPwm(OA_PWM_CH_0, 500000, 250000)");
+    static uint32_t period = 499999;
+    aexp.setPwm(OA_PWM_CH_0, period, 250000);
+    period++;
+    #endif
+    
+    digitalWrite(LED_USER,LOW);
+    Serial.println("Measured " + String(v));
+  }
+  
+
+}

--- a/tests/measureI2CtransactionDigital/measureI2CtransactionDigital.ino
+++ b/tests/measureI2CtransactionDigital/measureI2CtransactionDigital.ino
@@ -1,0 +1,80 @@
+#include "OptaBlue.h"
+
+#define OPTA_CONTROLLER_DETECT_PIN PG_8
+
+#define EXPANSION_INDEX 0
+
+//#define MEASURE_ADC_SINGLE
+//#define MEASURE_ADC_ALL_AT_ONCE
+#define MEASURE_ALL_DIGITAL_INPUT
+//#define MEASURE_ALL_DIGITAL_INPUT_AT_ONCE
+
+DigitalExpansion dexp;
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial) {
+    
+  }
+  Serial.println("TEST SETUP for measuring I2C timing on DIGITAL");
+  OptaController.begin();
+  
+  pinMode(OPTA_CONTROLLER_DETECT_PIN, INPUT_PULLUP);
+  pinMode(LED_USER, OUTPUT);
+
+  dexp = OptaController.getExpansion(EXPANSION_INDEX);
+  if(!dexp) {
+    while(1) {
+      Serial.println("Digital expansion not found");
+      delay(1000);
+    }
+  }
+
+}
+
+void loop() {
+  OptaController.update();
+  static int counter = 0;
+  static int measure = 0;
+  digitalWrite(LED_USER,LOW);
+  if(digitalRead(BTN_USER) == LOW) {
+    counter++;
+    if(counter > 10000) {
+      measure++;
+    }
+  }
+  else {
+    counter=0;
+    measure = 0;
+  }
+  if(measure == 1) {
+    digitalWrite(LED_USER,HIGH);
+    float v = 0;
+   
+    #ifdef MEASURE_ADC_SINGLE
+    Serial.println("executing dexp.analogRead(0, true);");
+    v = dexp.analogRead(0, true);
+    #endif
+
+    #ifdef MEASURE_ADC_ALL_AT_ONCE
+    Serial.println("executing aexp.updateAnalogInputs();");
+    dexp.updateAnalogInputs();
+    v = dexp.analogRead(0, false);
+    #endif
+
+    #ifdef MEASURE_ALL_DIGITAL_INPUT
+    Serial.println("executing dexp.digitalRead(0, true);");
+    v = dexp.digitalRead(0, true);
+    #endif
+
+    #ifdef MEASURE_ALL_DIGITAL_INPUT_AT_ONCE
+    Serial.println("executing dexp.updateDigitalInputs();");
+    dexp.updateDigitalInputs();
+    v = dexp.digitalRead(0, false);
+    #endif
+    
+    digitalWrite(LED_USER,LOW);
+    Serial.println("Measured " + String(v));
+  }
+
+}


### PR DESCRIPTION
This PR contains 3 commits all related:
1. a fix in the setDac for the Analog Expansion (a delay was introduced every time a setDac was performed, but this was supposed to be used only in case of problems)
2. the change of the I2C speed -> from 100kHz to 400KHz
3. 2 test sketches are added to measure the duration of the I2C transactions

There is an additional commit that fix a typo into a comment and has been added here for simplicity reason.