### PR TITLE
Opta Controller: Get pwm functions used wrong index

### DIFF
--- a/examples/Analog/PWM/PWM.ino
+++ b/examples/Analog/PWM/PWM.ino
@@ -101,6 +101,7 @@ void optaAnalogTask() {
          rising = 1;
       }
     }
+
     for(int i = 0; i < OptaController.getExpansionNum(); i++) {
 
       AnalogExpansion aexp = OptaController.getExpansion(i);
@@ -120,6 +121,25 @@ void optaAnalogTask() {
 	  aexp.setPwm(OA_FIRST_PWM_CH + 2, period, pulse);
 	  aexp.setPwm(OA_FIRST_PWM_CH + 3, period, pulse);
 	}
+      }
+    }
+    for(int i = 0; i < OptaController.getExpansionNum(); i++) {
+
+      AnalogExpansion aexp = OptaController.getExpansion(i);
+
+      if(aexp) {
+	Serial.println("PWM ch 0 period " +
+	String(aexp.getPwmPeriod(OA_FIRST_PWM_CH))+ 
+	  " pulse " + aexp.getPwmPulse(OA_FIRST_PWM_CH));
+	Serial.println("PWM ch 1 period " +
+	String(aexp.getPwmPeriod(OA_FIRST_PWM_CH + 1)) + 
+	" pulse " + aexp.getPwmPulse(OA_FIRST_PWM_CH + 1));
+	Serial.println("PWM ch 2 period " +
+	String(aexp.getPwmPeriod(OA_FIRST_PWM_CH + 2)) + 
+	  " pulse " + aexp.getPwmPulse(OA_FIRST_PWM_CH + 2));
+	Serial.println("PWM ch 3 period " +
+	String(aexp.getPwmPeriod(OA_FIRST_PWM_CH + 3))+ 
+	    " pulse " + aexp.getPwmPulse(OA_FIRST_PWM_CH + 2));
       }
     }
   }

--- a/src/AnalogExpansion.cpp
+++ b/src/AnalogExpansion.cpp
@@ -560,7 +560,7 @@ void AnalogExpansion::setPwm(uint8_t ch, uint32_t period, uint32_t pulse) {
     float period = (float)getPwmPeriod(ch);
     float pulse = (float)getPwmPulse(ch);
     if(period > 0 && pulse <= period) {
-      return pulse / period;
+      return pulse * 100.0 / period;
     }
     return 0.0;
 

--- a/src/AnalogExpansion.cpp
+++ b/src/AnalogExpansion.cpp
@@ -502,8 +502,17 @@ void AnalogExpansion::setPwm(uint8_t ch, uint32_t period, uint32_t pulse) {
    * the value is already up to date*/
 }
 
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+
 /* get Pwm period in micro seconds */
   uint32_t AnalogExpansion::getPwmPeriod(uint8_t ch) {
+    if (ch >= OA_FIRST_PWM_CH && ch <= OA_LAST_PWM_CH) {
+      ch = ch - OA_FIRST_PWM_CH;
+    }
+    else if(ch >= OA_PWM_CHANNELS_NUM) {
+      return 0;
+    }
+    
     uint32_t per_add = BASE_OA_PWM_ADDRESS + ch;
     if (!addressExist(per_add)) {
       return 0;
@@ -512,8 +521,18 @@ void AnalogExpansion::setPwm(uint8_t ch, uint32_t period, uint32_t pulse) {
       return iregs[per_add];
     }
   }
+
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+
   /* get Pwm pulse in micro seconds */
   uint32_t AnalogExpansion::getPwmPulse(uint8_t ch) {
+    if (ch >= OA_FIRST_PWM_CH && ch <= OA_LAST_PWM_CH) {
+      ch = ch - OA_FIRST_PWM_CH;
+    }
+    else if(ch >= OA_PWM_CHANNELS_NUM) {
+      return 0;
+    }
+    
     uint32_t pul_add = BASE_OA_PWM_ADDRESS + ch + OA_PWM_CHANNELS_NUM;
     if (!addressExist(pul_add)) {
       return 0;
@@ -521,8 +540,9 @@ void AnalogExpansion::setPwm(uint8_t ch, uint32_t period, uint32_t pulse) {
     else {
       return iregs[pul_add];
     }
-
   }
+
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
   float AnalogExpansion::getPwmFreqHz(uint8_t ch) {
     float period = (float)getPwmPeriod(ch);
@@ -533,6 +553,8 @@ void AnalogExpansion::setPwm(uint8_t ch, uint32_t period, uint32_t pulse) {
     return 0.0;
 
   }
+
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
   float AnalogExpansion::getPwmPulsePerc(uint8_t ch) {
     float period = (float)getPwmPeriod(ch);


### PR DESCRIPTION
This PR corrects the behavior of Get PWM functions:
``` 
uint32_t getPwmPeriod(uint8_t ch);
uint32_t getPwmPulse(uint8_t ch);
float getPwmFreqHz(uint8_t ch);
float getPwmPulsePerc(uint8_t ch);
```
Those functions accepted as `ch` parameter a number from 0 to 3. This was not aligned with the `setPwm()` function that required its `ch` parameter to be from OA_PWM_CH_0 to OA_PWM_CH_3.
Now the "get" functions accept as channel OA_PWM_CH_0 ... OA_PWM_CH_3 as parameter.
It has been maintained the old behavior (in order to maintain compatibility) so a user can continue to use 0..3 as parameter however this practice is deprecated.