### PR TITLE
Opta Analog: Pwm pulse and period changed together fix

### DIFF
--- a/src/AnalogExpansion.h
+++ b/src/AnalogExpansion.h
@@ -233,17 +233,42 @@ public:
 
   void beginChannelAsHighImpedance(uint8_t ch);
 
-  /*
-   * Set /get channel functions
+  /* PWM Functions:
+   * valid channels number for PWM functions from OA_PWM_CH_0 to OA_PWM_CH_3
+   * there is also OA_PWM_CH_FIRST (equal to OA_PWM_CH_0) and OA_PWM_CH_LAST 
+   * (OA_PWM_CH_3)
    */
-  /* period and pulse in micro seconds */
+  /* Set period and pulse in micro seconds for the channel ch 
+     valid channels are from OA_PWM_CH_0 to OA_PWM_CH_3 */
   void setPwm(uint8_t ch, uint32_t period, uint32_t pulse);
-  /* get Pwm period in micro seconds */
-  uint32_t getPwmPeriod(uint8_t ch);
-  /* get Pwm pulse in micro seconds */
-  uint32_t getPwmPulse(uint8_t ch);
 
+  /* Get period in micro seconds for the channel ch 
+     valid channels are from OA_PWM_CH_0 to OA_PWM_CH_3 
+     for compatibility reason this function also accept value from 0 to 3 however
+     this is deprecated 
+     Please note that this function only return the last value send to the
+     expansion */
+  uint32_t getPwmPeriod(uint8_t ch);
+  /* Get period in micro seconds for the channel ch 
+     valid channels are from OA_PWM_CH_0 to OA_PWM_CH_3 
+     for compatibility reason this function also accept value from 0 to 3 however
+     this is deprecated 
+     Please note that this function only return the last value send to the
+     expansion */
+  uint32_t getPwmPulse(uint8_t ch);
+  /* Get frequency in Hz for the channel ch 
+     valid channels are from OA_PWM_CH_0 to OA_PWM_CH_3 
+     for compatibility reason this function also accept value from 0 to 3 however
+     this is deprecated 
+     Please note that this function only return the last value send to the
+     expansion*/
   float getPwmFreqHz(uint8_t ch);
+  /* Get duty cycle in % for the channel ch 
+     valid channels are from OA_PWM_CH_0 to OA_PWM_CH_3 
+     for compatibility reason this function also accept value from 0 to 3 however
+     this is deprecated 
+     Please note that this function only return the last value send to the
+     expansion*/
   float getPwmPulsePerc(uint8_t ch);
 
   /* get adc converter bits of channel ch (if ch is configured as ADC)*/

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -2597,6 +2597,8 @@ void print_adc_configuration(uint16_t v) {
 void print_adc_control(uint16_t v, int d) {
   int ch = (d == OA_DUMMY_CHANNEL_DEVICE_0) ? 1 : 2;
   Serial.print(" ");
+  int ch = (d == OA_AN_DEVICE_0) ? 1 : 2;
+  Serial.print("# ADC CONTROL: ");
   if (v & 1) {
     Serial.print(String(ch) + " YES ");
   } else {
@@ -2865,7 +2867,9 @@ void OptaAnalog::debugDiConfiguration(uint8_t ch) {
   uint16_t r2 = 0;
   uint16_t reg = 0;
   read_reg(0x09, reg, ch);
-  read_reg(0x22, r2, get_dummy_channel(ch));
+  uint8_t device = GET_DEVICE_FROM_CHANNEL(ch);
+
+  read_direct_reg(device, 0x22, r2);
   print_digital_input_configuration(reg, r2);
 }
 

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -121,26 +121,27 @@ void OptaAnalog::configurePwmPulse(uint8_t ch, uint32_t _pulse_us) {
 /* -------------------------------------------------------------------------- */
 void OptaAnalog::updatePwm(uint8_t ch) {
 /* ------------------------------------------------------------------------ */
+  
   if (ch >= OA_PWM_CHANNELS_NUM) {
     return;
   }
-  if (pwm[ch].set_period_us == 0 && pwm[ch].active) {
+  
+  if (pwm[ch].set_period_us == 0) {
     pwm[ch].pwm.suspend();
-    pwm[ch].active = false;
-  } else {
+  } 
+  else {
     if (pwm[ch].set_pulse_us < pwm[ch].set_period_us) {
+
       if (pwm[ch].set_period_us != pwm[ch].period_us || pwm[ch].set_pulse_us != pwm[ch].pulse_us) {
+        Serial.println("Setting PWM ch " + String(ch));
+
+        pwm[ch].pwm.resume();
+
         pwm[ch].pwm.period_us(pwm[ch].set_period_us);
         pwm[ch].pwm.pulseWidth_us(pwm[ch].set_pulse_us);
 
         pwm[ch].period_us = pwm[ch].set_period_us;
         pwm[ch].pulse_us = pwm[ch].set_pulse_us;
-      }
-      if (!pwm[ch].active) {
-#ifdef ARDUINO_OPTA_ANALOG
-        pwm[ch].pwm.resume();
-        pwm[ch].active = true;
-#endif
       }
     }
   }
@@ -153,10 +154,12 @@ void OptaAnalog::suspendPwm(uint8_t ch) {
     return;
   }
 
-  if (pwm[ch].active) {
-    pwm[ch].pwm.suspend();
-    pwm[ch].active = false;
-  }
+  pwm[ch].pwm.suspend();
+  pwm[ch].period_us = 0;
+  pwm[ch].pulse_us = 0;
+  pwm[ch].set_period_us = 0;
+  pwm[ch].set_pulse_us = 0;
+
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
@@ -198,6 +201,7 @@ OptaAnalog::OptaAnalog()
   }
   /* ------------------------------------------------------------------------ */
 }
+
 
 /* BEGIN */
 /* -------------------------------------------------------------------------- */

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -131,20 +131,15 @@ void OptaAnalog::updatePwm(uint8_t ch) {
   } 
   else {
     if (pwm[ch].set_pulse_us < pwm[ch].set_period_us) {
-
       if (pwm[ch].set_period_us != pwm[ch].period_us || pwm[ch].set_pulse_us != pwm[ch].pulse_us) {
-        Serial.println("Setting PWM ch " + String(ch));
-
         pwm[ch].pwm.resume();
-
         pwm[ch].pwm.period_us(pwm[ch].set_period_us);
-        pwm[ch].pwm.pulseWidth_us(pwm[ch].set_pulse_us);
-
-        pwm[ch].period_us = pwm[ch].set_period_us;
-        pwm[ch].pulse_us = pwm[ch].set_pulse_us;
+        pwm[ch].pwm.pulseWidth_us(pwm[ch].set_pulse_us);      
       }
     }
   }
+  pwm[ch].period_us = pwm[ch].set_period_us;
+  pwm[ch].pulse_us = pwm[ch].set_pulse_us;
 
 }
 /* -------------------------------------------------------------------------- */

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -120,7 +120,7 @@ void OptaAnalog::configurePwmPulse(uint8_t ch, uint32_t _pulse_us) {
 
 /* -------------------------------------------------------------------------- */
 void OptaAnalog::updatePwm(uint8_t ch) {
-  /* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------ */
   if (ch >= OA_PWM_CHANNELS_NUM) {
     return;
   }
@@ -129,14 +129,13 @@ void OptaAnalog::updatePwm(uint8_t ch) {
     pwm[ch].active = false;
   } else {
     if (pwm[ch].set_pulse_us < pwm[ch].set_period_us) {
-      if (pwm[ch].set_period_us != pwm[ch].period_us) {
+      if (pwm[ch].set_period_us != pwm[ch].period_us || pwm[ch].set_pulse_us != pwm[ch].pulse_us) {
         pwm[ch].pwm.period_us(pwm[ch].set_period_us);
-      }
-      if (pwm[ch].set_pulse_us != pwm[ch].pulse_us) {
         pwm[ch].pwm.pulseWidth_us(pwm[ch].set_pulse_us);
+
+        pwm[ch].period_us = pwm[ch].set_period_us;
+        pwm[ch].pulse_us = pwm[ch].set_pulse_us;
       }
-      pwm[ch].period_us = pwm[ch].set_period_us;
-      pwm[ch].pulse_us = pwm[ch].set_pulse_us;
       if (!pwm[ch].active) {
 #ifdef ARDUINO_OPTA_ANALOG
         pwm[ch].pwm.resume();
@@ -145,6 +144,7 @@ void OptaAnalog::updatePwm(uint8_t ch) {
       }
     }
   }
+
 }
 /* -------------------------------------------------------------------------- */
 void OptaAnalog::suspendPwm(uint8_t ch) {

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -395,18 +395,6 @@ uint8_t OptaAnalog::get_add_offset(uint8_t ch) {
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
-uint8_t OptaAnalog::get_dummy_channel(uint8_t ch) {
-  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
-    /* those channels belongs to device 0 */
-    return OA_DUMMY_CHANNEL_DEVICE_0;
-  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
-    return OA_DUMMY_CHANNEL_DEVICE_1;
-  }
-  return ch;
-}
-
-/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
-
 uint8_t OptaAnalog::get_device(uint8_t ch) {
   if (ch == OA_DUMMY_CHANNEL_DEVICE_0) {
     return 0;
@@ -624,7 +612,13 @@ void OptaAnalog::configureAdcDiagnostic(uint8_t ch, bool en) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 void OptaAnalog::configureAdcDiagRejection(uint8_t ch, bool en) {
-  en_adc_diag_rej[ch] = en;
+  uint8_t device = 0;
+  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
+    device = 0;
+  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
+    device = 1;
+  }
+  en_adc_diag_rej[device] = en;
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
@@ -1458,8 +1452,13 @@ void OptaAnalog::configureDinDebounceSimple(uint8_t ch, bool en) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 void OptaAnalog::configureDinScaleComp(uint8_t ch, bool en) {
-  uint8_t d = get_device(ch);
-  di_scaled[d] = en;
+  uint8_t device = 0;
+  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
+    device = 0;
+  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
+    device = 1;
+  }
+  di_scaled[device] = en;
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
@@ -1468,8 +1467,13 @@ void OptaAnalog::configureDinCompTh(uint8_t ch, uint8_t v) {
   if (v >= 32) { // only 5 bits available
     v = 31;
   }
-  uint8_t d = get_device(ch);
-  di_th[d] = v;
+  uint8_t device = 0;
+  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
+    device = 0;
+  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
+    device = 1;
+  }
+  di_th[device] = v;
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
@@ -1530,7 +1534,11 @@ void OptaAnalog::sendDinConfiguration(uint8_t ch) {
 
     COMPARATOR_TH(reg_cfg, di_th[d]);
 
-    write_reg(OA_REG_DIN_THRESH, reg_cfg, get_dummy_channel(ch));
+    if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
+      write_reg(OA_REG_DIN_THRESH, reg_cfg, OA_DUMMY_CHANNEL_DEVICE_0);
+    } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
+      write_reg(OA_REG_DIN_THRESH, reg_cfg, OA_DUMMY_CHANNEL_DEVICE_1);
+    }
   }
 }
 
@@ -1832,11 +1840,11 @@ bool OptaAnalog::parse_setup_di_channel() {
       configureDinDebounceSimple(ch, false);
     }
     if (rx_buffer[OA_CH_DI_SCALE_COMP_POS] == OA_ENABLE) {
-      configureDinScaleComp(get_dummy_channel(ch), true);
+      configureDinScaleComp(ch, true);
     } else {
-      configureDinScaleComp(get_dummy_channel(ch), false);
+      configureDinScaleComp(ch, false);
     }
-    configureDinCompTh(get_dummy_channel(ch), rx_buffer[OA_CH_DI_COMP_TH_POS]);
+    configureDinCompTh(ch, rx_buffer[OA_CH_DI_COMP_TH_POS]);
 
     configureDinCurrentSink(ch, rx_buffer[OA_CH_DI_CURR_SINK_POS]);
     configureDinDebounceTime(ch, rx_buffer[OA_CH_DI_DEBOUNCE_TIME_POS]);
@@ -2015,10 +2023,10 @@ bool OptaAnalog::parse_setup_adc_channel() {
 
     if (rx_buffer[OA_CH_ADC_REJECTION_POS] == OA_ENABLE) {
       configureAdcRejection(ch, true);
-      configureAdcDiagRejection(get_dummy_channel(ch), true);
+      configureAdcDiagRejection(ch, true);
     } else if (rx_buffer[OA_CH_ADC_REJECTION_POS] == OA_DISABLE) {
       configureAdcRejection(ch, false);
-      configureAdcDiagRejection(get_dummy_channel(ch), false);
+      configureAdcDiagRejection(ch, false);
     }
     if (rx_buffer[OA_CH_ADC_DIAGNOSTIC_POS] == OA_ENABLE) {
       configureAdcDiagnostic(ch, true);

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -1758,7 +1758,14 @@ void OptaAnalog::update_live_status() {
  * The purpose of this function is to verify if the adc conversion is finished
  * for THAT channel (ch) */
 bool OptaAnalog::is_adc_conversion_finished(uint8_t ch) {
-  update_live_status(get_dummy_channel(ch));
+
+  uint8_t dummy = OA_DUMMY_CHANNEL_DEVICE_0;
+  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
+    dummy = OA_DUMMY_CHANNEL_DEVICE_0;
+  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
+    dummy = OA_DUMMY_CHANNEL_DEVICE_1;
+  }
+  update_live_status(dummy);
   // depending on the channel the device is different
   // and we select the device in this way (see
   // get_device function)
@@ -1772,7 +1779,7 @@ bool OptaAnalog::is_adc_conversion_finished(uint8_t ch) {
     // but we need to to convert "our" channel (from 0
     // to 7) to "device" channel (from 0 to 3)
     if (get_add_offset(ch) == ch_used) {
-      write_reg(OA_LIVE_STATUS, ADC_DATA_READY, get_dummy_channel(ch));
+      write_reg(OA_LIVE_STATUS, ADC_DATA_READY, dummy);
       return true;
     }
   }

--- a/src/OptaAnalog.h
+++ b/src/OptaAnalog.h
@@ -143,7 +143,8 @@ private:
   bool read_reg(uint8_t add, uint16_t &value, uint8_t ch);
   uint8_t get_add_offset(uint8_t ch);
   uint8_t get_device(uint8_t ch);
-  uint8_t get_dummy_channel(uint8_t ch);
+  
+
   bool read_direct_reg(uint8_t device, uint8_t addr, uint16_t &value);
   void write_direct_reg(uint8_t device, uint8_t addr, uint16_t value);
 

--- a/src/OptaAnalogTypes.h
+++ b/src/OptaAnalogTypes.h
@@ -97,7 +97,6 @@ public:
 class CfgPwm {
 public:
   PwmOut pwm;
-  bool active;
   /* period_us is the period set to the pwm (it is updated only when different
    * from set_period_us, this is necessary because if the period is continuously
    * updated the timer does not work as expected and the is not set properly)*/
@@ -109,7 +108,7 @@ public:
   /* set_pulse_us is the pulse set point */
   uint32_t set_pulse_us;
   CfgPwm(int p)
-      : pwm(p), active(false), period_us(0), pulse_us(0), set_period_us(0),
+      : pwm(p), period_us(0), pulse_us(0), set_period_us(0),
         set_pulse_us(0) {}
   void begin() {
     pwm.begin();


### PR DESCRIPTION
This PR fix the fact that PWM pulse and period were updated separately when requested, but when the period changes the settings of the pulse pwm might need to be updated too to have the correct PWM applied.
This PR make values always updated together so that PWM pulse is recalculated every time the period is changed.