### PR TITLE
Opta controller and expansions: assign address enhancement

### DIFF
--- a/src/OptaBlueModule.cpp
+++ b/src/OptaBlueModule.cpp
@@ -156,6 +156,7 @@ void Module::reset() {
   setStatusLedWaitingForAddress();
   /* put address to invalid */
   wire_i2c_address = OPTA_DEFAULT_SLAVE_I2C_ADDRESS;
+  rx_i2c_address = OPTA_DEFAULT_SLAVE_I2C_ADDRESS; 
   
   /* detect_in (toward Controller) as Output */
   pinMode(detect_in, OUTPUT);
@@ -175,7 +176,7 @@ void Module::reset() {
   
   /* put I2C address to the default one */
   if (Module::expWire != nullptr) {
-    Module::expWire->begin(wire_i2c_address);
+    Module::expWire->begin(OPTA_DEFAULT_SLAVE_I2C_ADDRESS);
   }
   
 }
@@ -547,6 +548,12 @@ void Module::updatePinStatus() {
 #if defined DEBUG_SERIAL && defined DEBUG_UPDATE_PIN_ENABLE
     Serial.println("ADDRESS not ACQUIRED");
 #endif
+
+    pinMode(detect_out, INPUT_PULLUP);
+    if(digitalRead(detect_out) == LOW) {
+      reset();
+    }
+
     setStatusLedReadyForAddress();
     /* detect_in (toward Controller) as Output */
     pinMode(detect_in, OUTPUT);


### PR DESCRIPTION
This PR avoid wrong address assignment in an un-realistic case: a single expansion in a chain of configured expansion is cyclically kept reset for a time that is compatible for other expansions to become available to receive a new I2C address. 
In this strange condition could sometimes happen that the assign I2C address process fail.
This PR "filter" this condition improving the address assignment. 