### PR TITLE
Opta Controller: Revision start up processes

### DIFF
--- a/AddCustomExpansion.md
+++ b/AddCustomExpansion.md
@@ -487,8 +487,19 @@ must be always implemented in the NewExpansionExpansion class:
   This function will be passed to the controller so that controller can
   re-initialize the expansions every time a discovery expansion process is
   finished.
-  If your expansion type does not need such function just write an empty
-  function. This will used in the copy constructor definition.
+  The startUp function are always called after the assign address process is completed.
+  Each startUp callback has to set up properly all the expansion of a certain type
+  in 2 possible situations:
+  - when the controller is re-programmed (since single expansion are not reset)
+    the startUp must send to all the expansions all that is need to put the expansion
+    in its "default state" (output off and so on...)
+  - when a single expansion is hot plug in into the chain (or one of the expansion
+    is reset for some reason) the startUp function must send to all the expansions 
+    of that type, all that is needed to put the expansion in last known state.
+  This is the approach used with digital and Analog expansion, however he behavior 
+  of a start up function could depend on how expansion FW works:
+  if your custom expansion type does not need such function just write an empty
+  function. 
 
 Then the new expansion class can define whatever custom additional function: the
 important point here is to remain to read / write / execute paradigm.

--- a/examples/getExpansions/getExpansions.ino
+++ b/examples/getExpansions/getExpansions.ino
@@ -15,7 +15,7 @@
 void printExpansionType(ExpansionType_t t) {
 /* -------------------------------------------------------------------------- */
   if(t == EXPANSION_NOT_VALID) {
-    Serial.print("Unknown!");
+    Serial.print("Unknown! (Might be an Unregistered custom expansion?)");
   }
   else if(t == EXPANSION_OPTA_DIGITAL_MEC) {
     Serial.print("Opta --- DIGITAL [Mechanical]  ---");

--- a/src/AnalogCommonCfg.h
+++ b/src/AnalogCommonCfg.h
@@ -17,7 +17,7 @@
 #ifndef COMMONANALOG
 #define COMMONANALOG
 
-typedef enum { OA_VOLTAGE_ADC, OA_CURRENT_ADC, OA_ADC_NOT_USED } OaAdcType_t;
+typedef enum { OA_VOLTAGE_ADC, OA_CURRENT_ADC } OaAdcType_t;
 typedef enum { OA_VOLTAGE_DAC, OA_CURRENT_DAC } OaDacType_t;
 
 #if defined ARDUINO_UNO_TESTALOG_SHIELD

--- a/src/AnalogExpansion.cpp
+++ b/src/AnalogExpansion.cpp
@@ -139,7 +139,11 @@ uint8_t AnalogExpansion::msg_begin_adc() {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_begin_di() {
-  //
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+      index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
     if (di_registers_defined()) {
       ctrl->setTx(iregs[ADD_OA_PIN], OA_CH_DI_CHANNEL_POS);
@@ -154,11 +158,11 @@ uint8_t AnalogExpansion::msg_begin_di() {
 
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_CH_DI,
                                  LEN_OA_CH_DI, OA_CH_DI_LEN);
-      if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-        cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
-        cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN],
-                           CFG_OA_CH_DI_LEN);
-      }
+      
+      AnalogExpansion::cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
+      AnalogExpansion::cfgs[index].backup(ctrl->getTxBuffer(), 
+                         iregs[ADD_OA_PIN] + OFFSET_CHANNEL_CONFIG,
+                         rv);
       return rv;
     }
   }
@@ -333,6 +337,11 @@ void AnalogExpansion::beginChannelAsCurrentDac(uint8_t ch) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_begin_dac() {
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
     if (dac_registers_defined()) {
       ctrl->setTx(iregs[ADD_OA_PIN], OA_CH_DAC_CHANNEL_POS);
@@ -343,17 +352,26 @@ uint8_t AnalogExpansion::msg_begin_dac() {
 
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_CH_DAC,
                                  LEN_OA_CH_DAC, OA_CH_DAC_LEN);
-      if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-        cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
-        cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN], rv);
-      }
+      
+      AnalogExpansion::cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
+      AnalogExpansion::cfgs[index].backup(ctrl->getTxBuffer(), 
+                         iregs[ADD_OA_PIN] + OFFSET_CHANNEL_CONFIG, 
+                         rv);
+      
       return rv;
     }
   }
   return 0;
 }
 
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+
 uint8_t AnalogExpansion::msg_begin_high_imp() {
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
 
     ctrl->setTx(iregs[ADD_OA_PIN], OA_HIGH_IMPEDENCE_CH_POS);
@@ -361,8 +379,10 @@ uint8_t AnalogExpansion::msg_begin_high_imp() {
         prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_CH_HIGH_IMPEDENCE,
                       LEN_OA_CH_HIGH_IMPEDENCE, OA_CH_HIGH_IMPEDENCE_LEN);
     if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-      cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
-      cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN], rv);
+      AnalogExpansion::cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
+      AnalogExpansion::cfgs[index].backup(ctrl->getTxBuffer(), 
+                         iregs[ADD_OA_PIN] + OFFSET_CHANNEL_CONFIG, 
+                         rv);
     }
     return rv;
   }
@@ -408,20 +428,24 @@ void AnalogExpansion::beginRtdUpdateTime(uint16_t time) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_set_rtd_time() {
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
     if (addressExist(ADD_OA_RTD_TIME)) {
       ctrl->setTx((uint8_t)(iregs[ADD_OA_RTD_TIME] & 0xFF),
                   OA_SET_RTD_UPDATE_TIME_POS);
       ctrl->setTx((uint8_t)((iregs[ADD_OA_RTD_TIME] & 0xFF00) >> 8),
                   OA_SET_RTD_UPDATE_TIME_POS + 1);
-
-      uint8_t rv =
-          prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_RTD_UPDATE_TIME,
+      
+      uint8_t rv =  prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_RTD_UPDATE_TIME,
                         LEN_OA_SET_RTD_UPDATE_TIME, OA_SET_RTD_UPDATE_TIME_LEN);
-      if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-        cfgs[index].backup(ctrl->getTxBuffer(), OA_RTD_UTIME_POS, rv);
-      }
+      cfgs[index].backup(ctrl->getTxBuffer(), OFFSET_RTD_UPDATE_TIME, rv);
+
       return rv;
+
     }
   }
   return 0;
@@ -430,6 +454,11 @@ uint8_t AnalogExpansion::msg_set_rtd_time() {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_begin_rtd() {
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
     if (rtd_registers_defined()) {
       ctrl->setTx(iregs[ADD_OA_PIN], OA_CH_RTD_CHANNEL_POS);
@@ -444,10 +473,11 @@ uint8_t AnalogExpansion::msg_begin_rtd() {
 
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_CH_RTD,
                                  LEN_OA_CH_RTD, OA_CH_RTD_LEN);
-      if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-        cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
-        cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN], rv);
-      }
+      
+      cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
+      cfgs[index].backup(ctrl->getTxBuffer(), 
+                         iregs[ADD_OA_PIN] + OFFSET_CHANNEL_CONFIG, 
+                         rv);
       return rv;
     }
   }
@@ -592,7 +622,7 @@ uint8_t AnalogExpansion::msg_set_pwm() {
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_PWM,
                                  LEN_OA_SET_PWM, OA_SET_PWM_LEN);
       if (index < OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
-        cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN] + OA_FIRST_PWM_CH, rv);
+        cfgs[index].backup(ctrl->getTxBuffer(), iregs[ADD_OA_PIN] + OFFSET_PWM_CONFIG, rv);
       }
       return rv;
     }
@@ -620,17 +650,8 @@ uint8_t AnalogExpansion::msg_get_adc() {
     if (addressExist(ADD_OA_PIN)) {
       ctrl->setTx(iregs[ADD_OA_PIN], OA_CH_ADC_CHANNEL_POS);
 
-      uint8_t rv = prepareGetMsg(ctrl->getTxBuffer(), ARG_OA_GET_ADC,
+      return prepareGetMsg(ctrl->getTxBuffer(), ARG_OA_GET_ADC,
                                  LEN_OA_GET_ADC, OA_GET_ADC_LEN);
-
-#ifdef DEBUG_GET_MSG_ADC
-      for (int i = 0; i < OA_GET_ADC_LEN_CRC; i++) {
-        Serial.print(ctrl->getTxBuffer()[i], HEX);
-        Serial.print(" ");
-      }
-      Serial.println();
-#endif
-      return rv;
     }
   }
   return 0;
@@ -724,6 +745,11 @@ void AnalogExpansion::setDac(uint8_t ch, uint16_t value,
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_set_dac() {
+  if( iregs[ADD_OA_PIN] >= OA_AN_CHANNELS_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
+
   if (ctrl != nullptr) {
     if (addressExist(ADD_OA_PIN) &&
         addressExist(BASE_OA_DAC_ADDRESS + iregs[ADD_OA_PIN])) {
@@ -739,6 +765,11 @@ uint8_t AnalogExpansion::msg_set_dac() {
       ctrl->setTx(iregs[ADD_UPDATE_ANALOG_OUTPUT], OA_SET_DAC_UPDATE_VALUE);
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_DAC,
                                  LEN_OA_SET_DAC, OA_SET_DAC_LEN);
+
+      AnalogExpansion::cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
+      AnalogExpansion::cfgs[index].backup(ctrl->getTxBuffer(), 
+                         iregs[ADD_OA_PIN] + OFFSET_DAC_VALUE, 
+                         rv);
 
       return rv;
     }
@@ -854,19 +885,19 @@ void AnalogExpansion::updateLeds() {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 uint8_t AnalogExpansion::msg_set_led() {
+  if( iregs[ADD_OA_PIN] >= OA_LED_NUM && 
+    index >= OPTA_CONTROLLER_MAX_EXPANSION_NUM) {
+    return 0;
+  }
   if (ctrl != nullptr) {
-
     if (addressExist(ADD_OA_LED_VALUE)) {
       ctrl->setTx(iregs[ADD_OA_LED_VALUE], OA_SET_LED_VALUE_POS);
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_LED,
                                  LEN_OA_SET_LED, OA_SET_LED_LEN);
-#ifdef DEBUG_SET_LED_MSG
-      for (int i = 0; i < rv; i++) {
-        Serial.print(ctrl->getTxBuffer()[i], HEX);
-        Serial.print(" ");
-      }
-      Serial.println();
-#endif
+
+      cfgs[index].backup(ctrl->getTxBuffer(), 
+                         OFFSET_LED_VALUE, 
+                         rv);
       return rv;
     }
   }
@@ -1146,9 +1177,6 @@ void AnalogExpansion::beginChannelAsAdc(Controller &ctrl, uint8_t device,
   if (device < OPTA_CONTROLLER_MAX_EXPANSION_NUM && ch < OA_AN_CHANNELS_NUM) {
     AnalogExpansion exp = ctrl.getExpansion(device);
     exp.beginChannelAsAdc(ch, type, pull_down, rejection, diagnostic, ma);
-    // if (!exp) {
-    // cfgs[device].backup(ctrl.getTxBuffer(), ch, CFG_OA_CH_ADC_LEN);
-    //}
   }
 }
 
@@ -1200,9 +1228,6 @@ void AnalogExpansion::beginChannelAsDigitalInput(
     /* expansion is already attached */
     exp.beginChannelAsDigitalInput(ch, filter, invert, simple_deb, sink_cur,
                                    deb_time, scale, th, Vcc);
-    // if (!exp) {
-    // cfgs[device].backup(ctrl.getTxBuffer(), ch, CFG_OA_CH_DI_LEN);
-    //}
   }
 }
 void AnalogExpansion::beginChannelAsDigitalInput(Controller &ctrl,
@@ -1220,9 +1245,6 @@ void AnalogExpansion::beginChannelAsRtd(Controller &ctrl, uint8_t device,
     AnalogExpansion exp = ctrl.getExpansion(device);
     /* expansion is already attached */
     exp.beginChannelAsRtd(ch, use_3_wires, current);
-    // if (!exp) {
-    // cfgs[device].backup(ctrl.getTxBuffer(), ch, CFG_OA_CH_RTD_LEN);
-    //}
   }
 }
 
@@ -1232,10 +1254,6 @@ void AnalogExpansion::beginRtdUpdateTime(Controller &ctrl, uint8_t device,
     AnalogExpansion exp = ctrl.getExpansion(device);
     /* expansion is already attached */
     exp.beginRtdUpdateTime(time);
-    // if (!exp) {
-    // cfgs[device].backup(ctrl.getTxBuffer(), OA_RTD_UTIME_POS,
-    //   CTRL_SET_RTD_TIME_LEN);
-    //}
   }
 }
 
@@ -1247,9 +1265,6 @@ void AnalogExpansion::beginChannelAsDac(Controller &ctrl, uint8_t device,
     AnalogExpansion exp = ctrl.getExpansion(device);
     /* expansion is already attached */
     exp.beginChannelAsDac(ch, type, limit_current, enable_slew, sr);
-    // if (!exp) {
-    // cfgs[device].backup(ctrl.getTxBuffer(), ch, CFG_OA_CH_DAC_LEN);
-    //}
   }
 }
 void AnalogExpansion::beginChannelAsVoltageDac(Controller &ctrl, uint8_t device,

--- a/src/AnalogExpansion.h
+++ b/src/AnalogExpansion.h
@@ -145,13 +145,7 @@ public:
    *    - MUX is on the 100R resistor
    *    - RANGE is 0-2.5V volt externally powered
    *    - PULL DOWN is DISABLE (the parameter 'pull_down' is disregarded)
-   *
-   * Note: in case OA_ADC_NOT_USED is used as 'type' parameter this function
-   * does nothing (since it makes no sense to "begin" a channel as ADC and tell
-   * the ADC is not used). This value is used when the channel is configured for
-   * "other" than ADC (typically DAC or DI) and the ADC function is used "in
-   * parallel" to the primary function to say there is no need of additional ADC
-   * configuration*/
+   */
   void beginChannelAsAdc(uint8_t ch, OaAdcType_t type, bool pull_down,
                          bool rejection, bool diagnostic, uint8_t ma);
   void addAdcOnChannel(uint8_t ch, OaAdcType_t type, bool pull_down,

--- a/src/AnalogExpansionCfg.h
+++ b/src/AnalogExpansionCfg.h
@@ -218,12 +218,6 @@ public:
   int8_t restore(uint8_t *dst, uint8_t ch) {
     if (ch < OA_CFG_MSG_NUM) {
       if (size[ch] != -1 && cfg[ch] != nullptr) {
-        Serial.print("-> ");
-        for(int i = 0; i < size[ch]; i++) {
-          Serial.print(cfg[ch][i],HEX);
-          Serial.print(" ");
-        }
-        
         memcpy(dst, cfg[ch], size[ch]);
         return size[ch];
       }

--- a/src/AnalogExpansionCfg.h
+++ b/src/AnalogExpansionCfg.h
@@ -14,15 +14,33 @@
 #ifndef ANALOGEXPANSIONCFG
 #define ANALOGEXPANSIONCFG
 
-
 #include "OptaAnalogProtocol.h"
 #include "OptaMsgCommon.h"
 #include <cstdint>
 #include <cstring>
-#define OA_CFG_MSG_NUM                                                         \
-  (OA_AN_CHANNELS_NUM + OA_PWM_CHANNELS_NUM + 1 + OA_AN_CHANNELS_NUM)
-#define OA_RTD_UTIME_POS (OA_AN_CHANNELS_NUM + OA_PWM_CHANNELS_NUM)
-#define OFFSET_ADD_ADC_MESSAGE (OA_AN_CHANNELS_NUM + OA_PWM_CHANNELS_NUM + 1)
+
+/* channels maps:
+   - first 8 cfgs are channels configuration (ADC, RTD, DAC etc)
+   - second 4 cfg are PWM channels configuration 
+   - then there is 1 position for RTD timing configuration
+   - then there are 8 position for additional ADC configuration
+   - then there are 8 position for last value channel output value (DAC)
+   - then there are 8 position for the last LED channel output value  */
+
+#define OA_CFG_MSG_NUM  (OA_AN_CHANNELS_NUM +  \
+                         OA_PWM_CHANNELS_NUM + \
+                         1 +                   \
+                         OA_AN_CHANNELS_NUM +  \
+                         OA_AN_CHANNELS_NUM +  \
+                         1 )
+
+#define OFFSET_CHANNEL_CONFIG  (0)
+#define OFFSET_PWM_CONFIG      (OFFSET_CHANNEL_CONFIG + OA_AN_CHANNELS_NUM)
+#define OFFSET_RTD_UPDATE_TIME (OFFSET_PWM_CONFIG + OA_PWM_CHANNELS_NUM)
+#define OFFSET_ADD_ADC_CONFIG  (OFFSET_RTD_UPDATE_TIME + 1)
+#define OFFSET_DAC_VALUE       (OFFSET_ADD_ADC_CONFIG + OA_AN_CHANNELS_NUM)
+#define OFFSET_LED_VALUE       (OFFSET_DAC_VALUE + OA_AN_CHANNELS_NUM)
+                                
 /* this class is used to store the last 'begin' message sent by the controller
  * to an Opta Analog so that it will be possible to quickly "restore" a device
  * configuration if the device is rebooted. There is 1 message for each channel
@@ -31,6 +49,7 @@ class OaChannelCfg {
 private:
   int8_t size[OA_CFG_MSG_NUM];
   uint8_t *cfg[OA_CFG_MSG_NUM];
+  bool device_is_used = false;
 
   /* function that allocates the configuration i for a size s
    * it deletes the configuration if already present
@@ -68,6 +87,10 @@ public:
     }
   }
 
+  bool isExpansionUsed() {
+    return device_is_used;
+  }
+
   bool isVoltageAdcCh(uint8_t ch) {
     if (is_cfg(ch)) {
       if (*(cfg[ch] + BP_ARG_POS) == ARG_OA_CH_ADC &&
@@ -76,9 +99,9 @@ public:
       }
     }
 
-    if (is_cfg(ch + OFFSET_ADD_ADC_MESSAGE)) {
-      if (*(cfg[OFFSET_ADD_ADC_MESSAGE + ch] + BP_ARG_POS) == ARG_OA_CH_ADC &&
-          *(cfg[OFFSET_ADD_ADC_MESSAGE + ch] + OA_CH_ADC_TYPE_POS) ==
+    if (is_cfg(ch + OFFSET_ADD_ADC_CONFIG)) {
+      if (*(cfg[OFFSET_ADD_ADC_CONFIG + ch] + BP_ARG_POS) == ARG_OA_CH_ADC &&
+          *(cfg[OFFSET_ADD_ADC_CONFIG + ch] + OA_CH_ADC_TYPE_POS) ==
               OA_VOLTAGE_ADC) {
         return true;
       }
@@ -94,9 +117,9 @@ public:
       }
     }
 
-    if (is_cfg(ch + OFFSET_ADD_ADC_MESSAGE)) {
-      if (*(cfg[OFFSET_ADD_ADC_MESSAGE + ch] + BP_ARG_POS) == ARG_OA_CH_ADC &&
-          *(cfg[OFFSET_ADD_ADC_MESSAGE + ch] + OA_CH_ADC_TYPE_POS) ==
+    if (is_cfg(ch + OFFSET_ADD_ADC_CONFIG)) {
+      if (*(cfg[OFFSET_ADD_ADC_CONFIG + ch] + BP_ARG_POS) == ARG_OA_CH_ADC &&
+          *(cfg[OFFSET_ADD_ADC_CONFIG + ch] + OA_CH_ADC_TYPE_POS) ==
               OA_CURRENT_ADC) {
         return true;
       }
@@ -105,10 +128,10 @@ public:
   }
 
   void resetAdditionalAdcCh(uint8_t ch) {
-    if (is_cfg(ch + OFFSET_ADD_ADC_MESSAGE)) {
-      delete[] cfg[ch + OFFSET_ADD_ADC_MESSAGE];
-      cfg[ch + OFFSET_ADD_ADC_MESSAGE] = nullptr;
-      size[ch + OFFSET_ADD_ADC_MESSAGE] = -1;
+    if (is_cfg(ch + OFFSET_ADD_ADC_CONFIG)) {
+      delete[] cfg[ch + OFFSET_ADD_ADC_CONFIG];
+      cfg[ch + OFFSET_ADD_ADC_CONFIG] = nullptr;
+      size[ch + OFFSET_ADD_ADC_CONFIG] = -1;
     }
   }
 
@@ -173,6 +196,7 @@ public:
   }
 
   void backup(uint8_t *src, uint8_t ch, uint8_t s) {
+    device_is_used = true;
     if (allocate(ch, s)) {
       memcpy(cfg[ch], src, s);
       size[ch] = s;
@@ -193,13 +217,38 @@ public:
 
   int8_t restore(uint8_t *dst, uint8_t ch) {
     if (ch < OA_CFG_MSG_NUM) {
-      if (size[ch] != -1) {
+      if (size[ch] != -1 && cfg[ch] != nullptr) {
+        Serial.print("-> ");
+        for(int i = 0; i < size[ch]; i++) {
+          Serial.print(cfg[ch][i],HEX);
+          Serial.print(" ");
+        }
+        
         memcpy(dst, cfg[ch], size[ch]);
         return size[ch];
       }
     }
     return 0;
   }
+
+#ifdef DEBUG_ANALOG_CONFIGURRATION
+  void print() {
+    Serial.println("");
+    for(int k = 0; k < OA_CFG_MSG_NUM; k++) {
+      Serial.print("Stored configuration " + String(k) + ": " );
+      if(size[k] != 0 && cfg[k] != nullptr) {
+        for(int i = 0; i < size[k]; i++) {
+          Serial.print(cfg[k][i],HEX);
+          Serial.print(" ");
+        }
+        Serial.println();
+      }
+      else {
+        Serial.println("NOT SET!!!");
+      }
+    }
+  }
+#endif
 
   /* DESTRUCTOR */
   ~OaChannelCfg() {

--- a/src/DigitalExpansion.h
+++ b/src/DigitalExpansion.h
@@ -55,6 +55,7 @@ protected:
 
   static uint16_t timeouts[OPTA_CONTROLLER_MAX_EXPANSION_NUM];
   static uint8_t defaults[OPTA_CONTROLLER_MAX_EXPANSION_NUM];
+  static uint8_t last_expansion_output[OPTA_CONTROLLER_MAX_EXPANSION_NUM];
 
 public:
   DigitalExpansion();

--- a/src/OptaAnalog.cpp
+++ b/src/OptaAnalog.cpp
@@ -598,12 +598,7 @@ void OptaAnalog::configureAdcDiagnostic(uint8_t ch, bool en) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 void OptaAnalog::configureAdcDiagRejection(uint8_t ch, bool en) {
-  uint8_t device = 0;
-  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
-    device = 0;
-  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
-    device = 1;
-  }
+  uint8_t device = GET_DEVICE_FROM_CHANNEL(ch);
   en_adc_diag_rej[device] = en;
 }
 
@@ -1438,12 +1433,7 @@ void OptaAnalog::configureDinDebounceSimple(uint8_t ch, bool en) {
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 void OptaAnalog::configureDinScaleComp(uint8_t ch, bool en) {
-  uint8_t device = 0;
-  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
-    device = 0;
-  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
-    device = 1;
-  }
+  uint8_t device = GET_DEVICE_FROM_CHANNEL(ch);
   di_scaled[device] = en;
 }
 
@@ -1453,12 +1443,7 @@ void OptaAnalog::configureDinCompTh(uint8_t ch, uint8_t v) {
   if (v >= 32) { // only 5 bits available
     v = 31;
   }
-  uint8_t device = 0;
-  if (ch == 0 || ch == 1 || ch == 6 || ch == 7) {
-    device = 0;
-  } else if (ch == 2 || ch == 3 || ch == 4 || ch == 5) {
-    device = 1;
-  }
+  uint8_t device = GET_DEVICE_FROM_CHANNEL(ch);
   di_th[device] = v;
 }
 

--- a/src/OptaController.cpp
+++ b/src/OptaController.cpp
@@ -34,13 +34,14 @@ class ExpType {
 
 private:
   makeExpansion_f make;
+  bool startUpFuncCalled;
   int type;
   std::string product;
   static int next_expansion_type;
 
 public:
   startUp_f startUp;
-  ExpType() : make(nullptr), type(-1), startUp(nullptr) {}
+  ExpType() : make(nullptr), startUpFuncCalled(false), type(-1), startUp(nullptr) {}
   void setType(int t) { type = t; }
   int setType() {
     type = next_expansion_type;
@@ -59,6 +60,15 @@ public:
   bool isProduct(std::string s) { return (product == s); }
   void setStart(startUp_f f) { startUp = f; }
   std::string getProduct() {return product;}
+  void enableStartUpCallback() {
+    startUpFuncCalled = false;
+  }
+  void callStartUp(Controller *p) {
+    if(startUpFuncCalled == false) {
+      startUp(p);
+      startUpFuncCalled = true;
+    }
+  }
 };
 
 int ExpType::next_expansion_type = EXPANSION_CUSTOM + 20;
@@ -147,15 +157,7 @@ int Controller::registerCustomExpansion(std::string pr, makeExpansion_f f,
   }
 
   /* looking for expansions registered after begin() (slower) */
-  for (int i = 0; i < num_of_exp; i++) {
-    if (exp_type[i] >= OPTA_CONTROLLER_CUSTOM_MIN_TYPE || exp_type[i] == EXPANSION_NOT_VALID) {
-      _send(exp_add[i], msg_get_product_type(), CTRL_ANS_MSG_GET_PRODUCT_LEN);
-      if (wait_for_device_answer(OPTA_BLUE_UNDEFINED_DEVICE_NUMBER,
-                                   CTRL_ANS_MSG_GET_PRODUCT_LEN, OPTA_CONTROLLER_WAIT_REQUEST_TIMEOUT)) {
-        exp_type[i] = parse_get_product();
-      }
-    }
-  }
+  assign_custom_type_and_call_start_up();
   return rv;
 }
 
@@ -258,7 +260,6 @@ Expansion *Controller::getExpansionPtr(int device) {
         #endif
         if (exp_type[device] == exp_type_list[i].getType()) {
           expansions[device] = exp_type_list[i].allocateExpansion();
-          setExpStartUpCb(exp_type_list[i].startUp);
           break;
         }
       }
@@ -346,22 +347,6 @@ int Controller::analogReadOpta(uint8_t device, uint8_t pin,
   // TODO (MAYBE): add analog
 }
 
-/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
-
-void Controller::setExpStartUpCb(reset_exp_f f) {
-  bool found = false;
-  for (unsigned int i = 0; i < reset_cbs.size(); i++) {
-    if (reset_cbs[i].fnc == f) {
-      found = true;
-      break;
-    }
-  }
-  if (!found) {
-    ResetCb rc;
-    rc.fnc = f;
-    reset_cbs.push_back(rc);
-  }
-}
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 // REVISED
@@ -558,6 +543,42 @@ bool Controller::is_detect_high() {
   }
 
   return (detect_st == HIGH);
+}
+
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+
+void Controller::assign_custom_type_and_call_start_up() {
+   /* safe to call this in the registerCustomExpansion function because:
+      - if the Controller.begin() function has been called then num_of_exp is
+        different from 0
+      - otherwise is 0 end the for loop does not work */
+   for (int i = 0; i < num_of_exp; i++) {
+      /* assign to expansion in position i a custom expansion type (if custom 
+         expansion has been registered */
+      if (exp_type[i] >= OPTA_CONTROLLER_CUSTOM_MIN_TYPE || exp_type[i] == EXPANSION_NOT_VALID) {
+        _send(exp_add[i], msg_get_product_type(), CTRL_ANS_MSG_GET_PRODUCT_LEN);
+        if (wait_for_device_answer(OPTA_BLUE_UNDEFINED_DEVICE_NUMBER,
+                                   CTRL_ANS_MSG_GET_PRODUCT_LEN, OPTA_CONTROLLER_WAIT_REQUEST_TIMEOUT)) {
+          /* return expansion not valid if product is not found*/
+          exp_type[i] = parse_get_product();
+          #if defined DEBUG_SERIAL && defined DEBUG_ASSIGN_ADDRESS_CONTROLLER
+          Serial.println("EXPANSION " + String(i) + " is custom with type " + exp_type[i]);
+          #endif
+        }
+      }
+
+      /* call start up functions */
+      if(exp_type[i] != EXPANSION_NOT_VALID) {
+         for(unsigned int k = 0; k < exp_type_list.size(); k++) {
+            if(exp_type[i] == exp_type_list[k].getType()) {
+               /* start can be called only once after the assign address process
+                  or after a registerCustomExpansion so it contains a flag 
+                  to avoid multiple calls */
+               exp_type_list[k].callStartUp(this);
+            }
+         }
+      }
+   }
 }
 
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
@@ -779,21 +800,11 @@ void Controller::checkForExpansions() {
     /* give some time to analog to reset Analog Devices */
     delay(OPTA_CONTROLLER_DELAY_EXPANSION_RESET);
 
-    /* for known expansion type (no custom) the type has already been assigned 
-       here we assing a type on custom expansion */
-    
-    for (int i = 0; i < num_of_exp; i++) {
-      if (exp_type[i] >= OPTA_CONTROLLER_CUSTOM_MIN_TYPE || exp_type[i] == EXPANSION_NOT_VALID) {
-        _send(exp_add[i], msg_get_product_type(), CTRL_ANS_MSG_GET_PRODUCT_LEN);
-        if (wait_for_device_answer(OPTA_BLUE_UNDEFINED_DEVICE_NUMBER,
-                                   CTRL_ANS_MSG_GET_PRODUCT_LEN, OPTA_CONTROLLER_WAIT_REQUEST_TIMEOUT)) {
-          exp_type[i] = parse_get_product();
-          #if defined DEBUG_SERIAL && defined DEBUG_ASSIGN_ADDRESS_CONTROLLER
-          Serial.println("EXPANSION " + String(i) + " is custom with type " + exp_type[i]);
-          #endif
-        }
-      }
-    }
+    /* reset the start up callback flag so that the callback can be called again*/
+    for(unsigned int i = 0; i < exp_type_list.size(); i++) {
+      exp_type_list[i].enableStartUpCallback();
+    }    
+    assign_custom_type_and_call_start_up();
 
 #if defined DEBUG_SERIAL && defined DEBUG_ASSIGN_ADDRESS_CONTROLLER
     Serial.print("FINAL Number of expansions found ");
@@ -808,23 +819,13 @@ void Controller::checkForExpansions() {
     delay(1000);
 #endif
 
-    /* at this point all the expansion have the final address, time to
-       make room for data from and to each expansion */
+    /* delete expansions (new expansions can be different from old ones) */
     for (int i = 0; i < OPTA_CONTROLLER_MAX_EXPANSION_NUM; i++) {
       if (expansions[i] != nullptr) {
         delete expansions[i];
         expansions[i] = nullptr;
       }
-    }
-
-    /* IMPORTANT: rest tmp_num_of_exp to 0 so it is ready for an other
-       possible assign address process */
-    tmp_num_of_exp = 0;
-
-    /* once the assign address is finished try to set up default  */
-    for (unsigned int i = 0; i < reset_cbs.size(); i++) {
-      reset_cbs[i].call(this);
-    }
+    }    
 
 #if defined DEBUG_SERIAL && defined DEBUG_ASSIGN_ADDRESS_CONTROLLER
     Serial.println();

--- a/src/OptaController.h
+++ b/src/OptaController.h
@@ -39,20 +39,6 @@ using namespace Opta;
 class Controller;
 
 using CommErr_f = void (*)(int device, int code);
-
-using reset_exp_f = void (*)(Controller *ptr);
-
-class ResetCb {
-public:
-  reset_exp_f fnc;
-  ResetCb() : fnc(nullptr) {}
-  void call(Controller *ptr) {
-    if (fnc != nullptr) {
-      fnc(ptr);
-    }
-  }
-};
-
 using makeExpansion_f = Expansion *(*)();
 using startUp_f = void (*)(Controller *);
 
@@ -71,9 +57,12 @@ public:
    In other word it is not guarantee htat a custom expansion always get the same 
    type "number"
    To get the number again use getExpansionType(std::string pr);
+   This is the only function that can be called before the begin() (and actually
+   it is better to call it _before_ however all works also if the custom
+   expansion is registered after the begin())
    */
   int registerCustomExpansion(std::string pr, makeExpansion_f f, startUp_f su);
-
+  void assign_custom_type_and_call_start_up();
   /* ----------------------------------------------------------- */
 
   /* initialize the controller it perform the assign address process */
@@ -117,7 +106,6 @@ public:
   /* ----------------------------------------------------------- */
 
   bool rebootExpansion(uint8_t i);
-  void setExpStartUpCb(reset_exp_f f);
   void setFailedCommCb(CommErr_f f);
 
   void updateRegs(Expansion &exp);
@@ -176,8 +164,7 @@ private:
   uint8_t exp_type[OPTA_CONTROLLER_MAX_EXPANSION_NUM];
   /* expansions arrays */
   Expansion *expansions[OPTA_CONTROLLER_MAX_EXPANSION_NUM];
-  /* vector of expansions callbacks, one for each expansion type */
-  std::vector<ResetCb> reset_cbs;
+  
 
   /* ---------------  generic message handling functions ----------------- */
 

--- a/src/OptaDigital.cpp
+++ b/src/OptaDigital.cpp
@@ -135,11 +135,9 @@ void OptaDigital::_resetOutputs() {
 
 /* -------------------------------------------------------------------------- */
 void OptaDigital::reset() {
-  /* --------------------------------------------------------------------------
-   */
+/* -------------------------------------------------------------------------- */
   /* reset output must be called first otherwise we get some delay from
      module reset and that make the output reset uneffective */
-  _resetOutputs();
   Module::reset();
 }
 

--- a/tests/testStressAnalogPlusPwm/testStressAnalogPlusPwm.ino
+++ b/tests/testStressAnalogPlusPwm/testStressAnalogPlusPwm.ino
@@ -15,6 +15,8 @@
 
 #include <cstdlib>
 #include "OptaBlue.h"
+#include "R4DisplayExpansion.h"
+
 
 AnalogExpansion out_expansion;
 AnalogExpansion in_expansion;
@@ -37,6 +39,37 @@ AnalogExpansion in_expansion;
 
 
    */
+
+/* -------------------------------------------------------------------------- */
+void printExpansionType(ExpansionType_t t) {
+/* -------------------------------------------------------------------------- */
+  if(t == EXPANSION_NOT_VALID) {
+    Serial.print("TYPE NOT VALID (perhaps custom expansion has not been registered?)");
+  }
+  else if(t == EXPANSION_OPTA_DIGITAL_MEC) {
+    Serial.print("Opta --- DIGITAL [Mechanical]  ---");
+  }
+  else if(t == EXPANSION_OPTA_DIGITAL_STS) {
+    Serial.print("Opta --- DIGITAL [Solid State] ---");
+  }
+  else if(t == EXPANSION_DIGITAL_INVALID) {
+    Serial.print("Opta --- DIGITAL [!!Invalid!!] ---");
+  }
+  else if(t == OptaController.getExpansionType(R4DisplayExpansion::getProduct()))
+  {
+     Serial.print("*** UnoR4 Display ***");
+  }
+  else if(t == OptaController.getExpansionType("ARDUINO UNO R4 WIFI"))
+  {
+     Serial.print("+++ UnoR4 WIFI ++++");
+  }
+  else if(t == EXPANSION_OPTA_ANALOG) {
+    Serial.print("Opta ~~~ ANALOG ~~~ ");
+  }
+  else {
+    Serial.print("Unknown!");
+  }
+}
 
 
 void setExpansionAsOutput_1(AnalogExpansion &a) {
@@ -229,6 +262,10 @@ void digitalTask() {
    }
 }
 
+std::string debug_getProduct() {
+  std::string rv("ARDUINO UNO R4 WIFI");
+  return rv;
+}
 
 /* -------------------------------------------------------------------------- */
 /*                                 SETUP                                      */
@@ -241,6 +278,17 @@ void setup() {
    srand(millis());
 
    OptaController.begin();
+
+   int type = OptaController.registerCustomExpansion(R4DisplayExpansion::getProduct(),
+                                         R4DisplayExpansion::makeExpansion,
+                                         R4DisplayExpansion::startUp);
+
+   Serial.println("Custom expansion type for R4 display " + String(type));
+   type = OptaController.registerCustomExpansion(debug_getProduct(),
+                                         R4DisplayExpansion::makeExpansion,
+                                         R4DisplayExpansion::startUp);
+   Serial.println("Custom expansion type for R4 WIFI " + String(type));
+
    initReverse_1();
 
    AnalogExpansion rtd_in = OptaController.getExpansion(RTD_EXPANSION_INDEX);
@@ -294,6 +342,15 @@ void loop() {
    static uint8_t configuration = 0;
 
    OptaController.update();
+
+   for(int i = 0; i < OptaController.getExpansionNum(); i++) {
+      Serial.print("Expansion n. ");
+      Serial.print(i);
+      Serial.print(" type ");
+      printExpansionType(OptaController.getExpansionType(i));
+      Serial.print(" I2C address ");
+      Serial.println(OptaController.getExpansionI2Caddress(i));
+   }
 
    /* TEST adc and dac ---- expansion 0 and 1 */
    


### PR DESCRIPTION
This PR better defines the expected behavior of an expansion at the end and during the assign I2C address process.
I2C assign process is performed following a reset of the controller or of one of the expansions (hot plug).
In case of the controller reset (due to a re-programming for example) the startUp functions ensure that both Digital and Analog expansion are reset to their default state (this ensure the proper execution of a new program).
In case a new expansion is plugged (or one of the expansion is reset for some reason) the startUp functions send to the expansion its last known configuration ensuring that nothing changes during and after the I2C assignment process (i.e. an expansion keep its current state during a new assignment address due to insertion of a new expansion).