### PR TITLE
Opta Controller / Analog Expansion: fixing problems on additional ADC configuration

### DIFF
--- a/src/AnalogExpansion.cpp
+++ b/src/AnalogExpansion.cpp
@@ -80,6 +80,8 @@ void AnalogExpansion::startUp(Controller *ptr) {
           if (tx_bytes) {
             ptr->send(exp.getI2CAddress(), exp.getIndex(), exp.getType(),
                       tx_bytes, CTRL_ANS_OA_LEN);
+            /* channel configuration takes some times on the expansion side*/
+            delay(50);
           }
         }
         exp.updateAnalogOutputs();
@@ -766,7 +768,6 @@ uint8_t AnalogExpansion::msg_set_dac() {
       uint8_t rv = prepareSetMsg(ctrl->getTxBuffer(), ARG_OA_SET_DAC,
                                  LEN_OA_SET_DAC, OA_SET_DAC_LEN);
 
-      AnalogExpansion::cfgs[index].resetAdditionalAdcCh(iregs[ADD_OA_PIN]);
       AnalogExpansion::cfgs[index].backup(ctrl->getTxBuffer(), 
                          iregs[ADD_OA_PIN] + OFFSET_DAC_VALUE, 
                          rv);

--- a/src/DigitalExpansion.cpp
+++ b/src/DigitalExpansion.cpp
@@ -106,7 +106,7 @@ void DigitalExpansion::startUp(Controller *ptr) {
                        LEN_OPTDIG_DIGITAL_OUT,
                        MSG_SET_OPTDIG_DIGITAL_OUT_LEN);
       if(tx_bytes) {
-        uint8_t res = ptr->send(exp.getI2CAddress(), exp.getIndex(), exp.getType(), tx_bytes,
+        ptr->send(exp.getI2CAddress(), exp.getIndex(), exp.getType(), tx_bytes,
                 CTRL_ANS_MSG_OD_DIGITAL_OUT);
       }
     }


### PR DESCRIPTION
- Additional ADC configuration were erroneously reset when DAC output were set
- Additional ADC configuration were not successfully restored due to Analog FW taking some time to set the correct configuration
Related to PR #16 

Also fixed warning on Digital expansion