### PR TITLE
Use standardized `maintainer` metadata property value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_Opta_Blueprint
 version=0.2.6
 author=Daniele Aimo (d.aimo@arduino.cc)
-maintainer=Daniele Aimo (d.aimo@arduino.cc)
+maintainer=Arduino <info@arduino.cc>
 sentence=Library used to connect OPTA and OPTA Expansion Modules on I2C / UART 
 paragraph=This library discover the presence of different Expansions (for example OPTA Digital) present on the I2C bus, automatically assing addresses to them and allow to control their Input/Output from the Opta Controller.
 category=Communication


### PR DESCRIPTION
The `maintainer` property of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) defines the entity responsible for maintenance of the library.

In the libraries that are under Arduino's maintainership, it is standard practice to set the `maintainer` property to the general purpose value `Arduino <info@arduino.cc>`.

Previously, instead of that standard value, this library's `maintainer` property defined a specific Arduino team member as the maintainer. This is prone to "bit rot", as the scope of each individual's work may change over time, or they may even move on from working for Arduino. It is unlikely that the team member will remember to update the metadata values at such time as they are no longer able to dedicate themselves to maintaining the library. So the metadata is changed to use the standard value.

It is commendable for individual team members to take responsibility for maintenance of specific libraries. However, doing so is not in any way dependent on the value of a metadata property. The change to the metadata does not imply any change to maintenance responsibilities for the project.