### PR TITLE
fix: Don't treat Major and minor the same in the version-comparison

### DIFF
--- a/examples/updateExpansionFw/updateExpansionFw.ino
+++ b/examples/updateExpansionFw/updateExpansionFw.ino
@@ -35,14 +35,14 @@ static unsigned char oa_type = opta_analog_fw_update[oa_fw_size];
 static unsigned char oa_M = opta_analog_fw_update[oa_fw_size + 1];
 static unsigned char oa_m = opta_analog_fw_update[oa_fw_size + 2];
 static unsigned char oa_r = opta_analog_fw_update[oa_fw_size + 3];
-static unsigned int  oa_version = oa_M * 255 + oa_m * 255 + oa_r;
+static unsigned int  oa_version = (oa_M << 16) | (oa_m << 8) | oa_r;
 
 static uint32_t od_fw_size = sizeof(opta_digital_fw_update) - 4;
 static unsigned char od_type = opta_digital_fw_update[od_fw_size];
 static unsigned char od_M = opta_digital_fw_update[od_fw_size + 1];
 static unsigned char od_m = opta_digital_fw_update[od_fw_size + 2];
 static unsigned char od_r = opta_digital_fw_update[od_fw_size + 3];
-static unsigned int  od_version = od_M * 255 + od_m * 255 + od_r;
+static unsigned int  od_version = (od_M << 16) | (od_m << 8) | od_r;
 
 static char *fileptr = nullptr;
 
@@ -91,7 +91,7 @@ bool isUpdatable(int device) {
    if(OptaController.getFwVersion(device,M,m,r)) {
       Serial.print(" Current FW version: ");
       printVersion(M,m,r);
-      unsigned int current_version = M * 255 + m * 255 + r;
+      unsigned int current_version = (M << 16) | (m << 8) | r;
       if(EXPANSION_OPTA_DIGITAL_MEC == type || EXPANSION_OPTA_DIGITAL_STS == type) {
          if(od_version > current_version ) {
             rv = true;

--- a/tests/testUpdateFw/testUpdateFw.ino
+++ b/tests/testUpdateFw/testUpdateFw.ino
@@ -40,14 +40,14 @@ static unsigned char oa_type = opta_analog_fw_update[oa_fw_size];
 static unsigned char oa_M = opta_analog_fw_update[oa_fw_size + 1];
 static unsigned char oa_m = opta_analog_fw_update[oa_fw_size + 2];
 static unsigned char oa_r = opta_analog_fw_update[oa_fw_size + 3];
-static unsigned int  oa_version = oa_M * 100 + oa_m * 10 + oa_r;
+static unsigned int  oa_version = (oa_M << 16) | (oa_m << 8) | oa_r;
 
 static uint32_t od_fw_size = sizeof(opta_digital_fw_update) - 4;
 static unsigned char od_type = opta_digital_fw_update[od_fw_size];
 static unsigned char od_M = opta_digital_fw_update[od_fw_size + 1];
 static unsigned char od_m = opta_digital_fw_update[od_fw_size + 2];
 static unsigned char od_r = opta_digital_fw_update[od_fw_size + 3];
-static unsigned int  od_version = od_M * 100 + od_m * 10 + od_r;
+static unsigned int  od_version = (od_M << 16) | (od_m << 8) | od_r;
 
 static char *fileptr = nullptr;
 
@@ -94,7 +94,7 @@ bool isUpdatable(int device) {
    if(controller.getFwVersion(device,M,m,r)) {
       Serial.print(" Current FW version: ");
       printVersion(M,m,r);
-      unsigned int current_version = M * 100 + m * 10 + r;
+      unsigned int current_version = (M << 16) | (m << 8) | r;
       if(EXPANSION_OPTA_DIGITAL_MEC == type || EXPANSION_OPTA_DIGITAL_STS == type) {
          if(od_version > current_version ) {
             rv = true;


### PR DESCRIPTION
This PR improves the firmware-update check and prevents treating the major and minor version of an incoming firmware the same.
The current behaviour would lead to 0.1.1 beeing detected as a more recent version than 1.0.0.
The provided test passed on a Analog and Digital Expansion.